### PR TITLE
Add iOS binding, configuration via Cordova preferences

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+- Android and iOS bindings for native adapters, with basic `start` and `stop` API
+- optional plugin configuration via `config.xml` preferences

--- a/README.md
+++ b/README.md
@@ -1,0 +1,204 @@
+# Gimbal Airship Adapter - Cordova Plugin
+
+The Gimbal Airship Adapter Cordova Plugin integrates Gimbal Place Event triggers with Airship Custom Events in Cordova apps.
+
+## Resources
+
+- [Gimbal Developer Guide](https://gimbal.com/doc/android/v4/devguide.html)
+- [Gimbal Manager Portal](https://manager.gimbal.com)
+- [Airship Getting Started guide](https://docs.airship.com/platform/android/getting-started/)
+- [Airship and Gimbal Integration guide](https://docs.airship.com/partners/gimbal/)
+
+## Installation
+
+### Prerequisites
+
+In [Gimbal Manager > Apps](https://manager.gimbal.com/apps) create an app for each iOS and Android.
+(For the purposes of differentiating between them in analytics, it helps to make the names and bundle/package IDs unique.)
+You can find your apps' API keys in the app detail view -- you will need these later.
+
+### Add the plugin
+
+To add the plugin to your app:
+
+```shell
+    cordova plugin add cordova-plugin-gimbal-airship-adapter
+```
+
+## Initialization
+
+This plugin allows configuration and setup via method calls, or via Cordova preferences in your app's `config.xml`.
+
+### Start with preferences
+
+If you want to just get it started, this is for you.
+
+```xml
+<widget ...>
+    ...
+    <preference name="com.gimbal.api_key.android" value="<YOUR_GIMBAL_ANDROID_API_KEY>" />
+    <preference name="com.gimbal.api_key.ios" value="<YOUR_GIMBAL_IOS_API_KEY>" />
+    <preference name="com.gimbal.auto_start" value="true" />
+</widget>
+```
+
+If auto-start is enabled, and the API key is set, Gimbal will start.
+Without an API key, auto-start has no effect.
+
+By default, Airthip Custom Event tracking is enabled for Gimbal Place Entry and Departure events.
+Airship Region Event tracking is disabled by default.
+
+### Start with code
+
+To start the adapter call:
+
+```javascript
+Gimbal.start('<YOUR_GIMBAL_API_KEY>',
+    (started) => console.log('Running Gimbal Airship Adapter: ' + started),
+    () => console.log('Failed to start Gimbal Airship Adapter'));
+```
+
+NOTE: your iOS and Android apps are managed separately in Gimbal Manager, and have separate API keys.
+Your code will need to determine which platform it is running on, so that it may supply the correct API key, e.g. with `cordova-plugin-device`:
+
+```javascript
+var apiKey = null;
+
+switch (device.platform) {
+    case 'iOS':
+        apiKey = '<YOUR_GIMBAL_IOS_API_KEY>';
+        break;
+    case 'Android':
+        apiKey = '<YOUR_GIMBAL_ANDROID_API_KEY>';
+        break;
+    default:
+        console.log('Platform ' + device.platform + ' not supported by Gimbal SDK');
+        return;
+}
+
+Gimbal.start(apiKey,
+    (started) => console.log('Running Gimbal Airship Adapter: ' + started),
+    () => console.log('Failed to start Gimbal Airship Adapter'));
+```
+
+Once the adapter is started, it will automatically resume its last state when the app is restarted, including if started in the background. 
+The API key and the started status are persisted between app starts -- you only need to call `start`  once.
+
+Typically this will be called when the user has opted-in to a feature that benefits from location-triggered Airship notifications, after the appropriate permissions are granted by the user.
+It is also possible to call `start` every time in your `onDeviceReady` callback, but note that the first time that permissions are granted (*after* Gimbal is started), Gimbal will not request location updates from the OS until the next app restart.
+
+NOTE: if your preferences also provide an API key and auto-start is enabled, calling `start()` may have unintended consequences.
+When `start()` is called with an API key that doesn't match the API key in preferences, the `start()` key wins.
+But once `stop()` is called, upon the next app start Gimbal will be auto-started with the API key in preferences.
+
+## Permissions
+
+This Adapter does not make requests on behalf of the app, as location permission flow has gotten far too complex -- it can't presume to know how or when any particular app should make its requests.
+If granted, Gimbal will use fine, coarse and background location permissions, as well as Bluetooth scan permission, to be as location-aware as it can.
+
+### iOS
+
+
+
+```xml
+<widget ...>
+    ...
+        <platform name="ios">
+        <edit-config file="*-Info.plist" target="NSLocationAlwaysUsageDescription" mode="merge">
+            <string>We require location permissions to detect place arrivals and exits</string>
+        </edit-config>
+        <edit-config file="*-Info.plist" target="NSLocationWhenInUseUsageDescription" mode="merge">
+            <string>We require location permissions to detect place arrivals and exits</string>
+        </edit-config>
+        <edit-config file="*-Info.plist" target="NSLocationAlwaysAndWhenInUseUsageDescription" mode="merge">
+            <string>We require location permissions to detect place arrivals and exits</string>
+        </edit-config>
+        <edit-config file="*-Info.plist" target="NSBluetoothAlwaysUsageDescription" mode="merge">
+            <string>We require bluetooth for beacon detection</string>
+        </edit-config>
+        <edit-config file="*-Info.plist" target="NSBluetoothPeripheralUsageDescription" mode="merge">
+            <string>We require bluetooth for beacon detection</string>
+        </edit-config>
+        <edit-config file="*-Info.plist" target="UIBackgroundModes" mode="merge">
+            <array>
+                <string>location</string>
+                <string>processing</string> <!-- required by Airship -->
+            </array>
+        </edit-config>
+    </platform>
+</widget>
+```
+
+### Android
+
+Before the adapter is able to request location updates on Android API 23 or newer, the app must request the location permission `ACCESS_FINE_LOCATION` (and `ACCESS_COARSE_LOCATION` on Android API 31+).
+The Gimbal SDK will still operate when granted only `ACCESS_COARSE_LOCATION` but only very large, region-sized geofences will trigger geofence place entries.
+
+Once the permissions are granted, then call this adapter's `start()` method.
+It is possible to start the adapter prior to acceptance of permissions, but then Gimbal may not be able to request location updates to trigger Airship events until the next app start.
+
+Note: The app will need `ACCESS_BACKGROUND_LOCATION` permissions Gimbal's to process place events while the app is in the background, if this functionality is desired.
+
+```xml
+<widget ...>
+    ...
+    <platform name="android">
+        ...
+        <preference name="AndroidXEnabled" value="true" />
+        <resource-file src="google-services.json" target="app/google-services.json" />
+        <config-file after="uses-permission" parent="/manifest" target="AndroidManifest.xml">
+            <uses-permission android:name="android.permission.ACCESS_BACKGROUND_LOCATION" />
+        </config-file>
+    </platform>
+</widget>
+```
+
+## Event Tracking
+
+The adapter can be configured to track Airship Events when Gimbal Place Events are triggered.
+Event tracking is controlled via `config.xml` preferences.
+Most apps will want to use either Custom Events or Region Events, but not both.
+Airship recommends using Custom Events, which are enabled by default.
+
+The following are the default event tracking preferences:
+
+```xml
+<widget ...>
+    ...
+    <preference name="com.gimbal.track_custom_events.entry" value="true" />
+    <preference name="com.gimbal.track_custom_events.exit" value="true" />
+    <preference name="com.gimbal.track_region_events" value="false" />
+</widget>    
+```
+
+### CustomEvents
+
+Place entry events are tracked as `gimbal_custom_entry_event` and departure events are tracked as `gimbal_custom_exit_event`.
+
+Each `CustomEvent` is populated with the following properties:
+
+- `visitID` - a UUID for the Gimbal Visit. This is common for the visit's entry and departure.
+- `placeIdentifier` - a UUID for the Gimbal Place
+- `placeName` - the human readable place name as entered in Gimbal Manager. Not necessarily unique!
+- `source` - always Gimbal
+- `boundaryEvent` - an enumeration of `1` for entry and `2` for exit/departure
+
+If there are any Place Attributes key-value pairs (as set on the triggering place in Gimbal Manager) present on the place that triggered the event, they will also be added to the `CustomEvent` properties.
+They are prefixed with `GMBL_PA_`, e.g. `DMA:825` becomes `GMBL_PA_DMA:825`.
+
+For more information regarding Airship Custom Events, see the Airship [Custom Event](https://docs.airship.com/guides/messaging/user-guide/data/custom-events/index.html) documentation.
+
+### RegionEvents
+
+When enabled, `RegionEvents` are created and tracked for both Place entries AND departures.
+
+## Stopping the adapter
+
+Adapter can be stopped at anytime by calling:
+
+```java
+   AirshipAdapter.shared(context).stop();
+```
+
+Once `stop()` is called, Gimbal location event processing will not restart upon subsequent app starts, until `start()` is called again.
+The exception is when the `auto-start` and API key preferences are set -- this behavior can't be overridden with code.

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ The Gimbal Airship Adapter Cordova Plugin integrates Gimbal Place Event triggers
 
 - [Gimbal Developer Guide](https://gimbal.com/doc/android/v4/devguide.html)
 - [Gimbal Manager Portal](https://manager.gimbal.com)
+- [Airship Cordova Plugin](https://github.com/urbanairship/urbanairship-cordova)
 - [Airship Getting Started guide](https://docs.airship.com/platform/android/getting-started/)
 - [Airship and Gimbal Integration guide](https://docs.airship.com/partners/gimbal/)
 
@@ -16,6 +17,8 @@ The Gimbal Airship Adapter Cordova Plugin integrates Gimbal Place Event triggers
 In [Gimbal Manager > Apps](https://manager.gimbal.com/apps) create an app for each iOS and Android.
 (For the purposes of differentiating between them in analytics, it helps to make the names and bundle/package IDs unique.)
 You can find your apps' API keys in the app detail view -- you will need these later.
+
+This plugin also requires `urbanairship-cordova` plugin to be installed and configured appropriately.
 
 ### Add the plugin
 
@@ -32,6 +35,11 @@ This plugin allows configuration and setup via method calls, or via Cordova pref
 ### Start with preferences
 
 If you want to just get it started, this is for you.
+If auto-start is enabled, and the API key is set, Gimbal will start.
+Without an API key, auto-start has no effect.
+
+The downside to this approach is that Gimbal will be running *before* any permissions are granted, and may not request location updates from the OS until the next app start.
+This may result in missed place events, and missed opportunities to engage with the customer.
 
 ```xml
 <widget ...>
@@ -41,9 +49,6 @@ If you want to just get it started, this is for you.
     <preference name="com.gimbal.auto_start" value="true" />
 </widget>
 ```
-
-If auto-start is enabled, and the API key is set, Gimbal will start.
-Without an API key, auto-start has no effect.
 
 By default, Airthip Custom Event tracking is enabled for Gimbal Place Entry and Departure events.
 Airship Region Event tracking is disabled by default.
@@ -81,11 +86,11 @@ Gimbal.start(apiKey,
     () => console.log('Failed to start Gimbal Airship Adapter'));
 ```
 
-Once the adapter is started, it will automatically resume its last state when the app is restarted, including if started in the background. 
+Once the adapter is started, it will automatically resume its last state when the app is restarted, including if started in the background.
 The API key and the started status are persisted between app starts -- you only need to call `start`  once.
 
 Typically this will be called when the user has opted-in to a feature that benefits from location-triggered Airship notifications, after the appropriate permissions are granted by the user.
-It is also possible to call `start` every time in your `onDeviceReady` callback, but note that the first time that permissions are granted (*after* Gimbal is started), Gimbal will not request location updates from the OS until the next app restart.
+It is also possible to call `start` every time in your `onDeviceReady` callback, but note that the first time that permissions are granted (*after* Gimbal is started), Gimbal may not request location updates from the OS until the next app restart.
 
 NOTE: if your preferences also provide an API key and auto-start is enabled, calling `start()` may have unintended consequences.
 When `start()` is called with an API key that doesn't match the API key in preferences, the `start()` key wins.

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "cordova": {
     "id": "cordova-plugin-gimbal-airship-adapter",
     "platforms": [
-      "android"
+      "android",
+      "ios"
     ]
   },
   "repository": {
@@ -14,8 +15,17 @@
   },
   "keywords": [
     "ecosystem:cordova",
-    "cordova-android"
+    "cordova-android",
+    "cordova-ios"
   ],
+  "engines": {
+    "cordovaDependencies": {
+      "0.0.1": { 
+        "cordova-ios": ">=6.2.0",
+        "cordova-android": ">=11.0.0"
+      }
+    }
+  },
   "author": "Gimbal Developers",
   "license": "Apache 2.0",
   "bugs": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cordova-plugin-gimbal-airship-adapter",
   "version": "0.0.1",
-  "description": "Gimbal Airship Adapter Cordova Plugin",
+  "description": "Gimbal Airship Adapter Cordova Plugin - use Gimbal PlaceEvents to trigger Airship CustomEvents",
   "cordova": {
     "id": "cordova-plugin-gimbal-airship-adapter",
     "platforms": [

--- a/plugin.xml
+++ b/plugin.xml
@@ -16,6 +16,7 @@
 
     <engines>
         <engine name="cordova-android" version=">=11.0.0" />
+        <engine name="cordova-ios" version=">=6.2.0" />
     </engines>
 
 	<platform name="android">
@@ -34,4 +35,23 @@
 
 		<framework custom="true" src="src/android/plugin.gradle" type="gradleReference"/>
 	</platform>
+    <platform name="ios">
+        <config-file target="config.xml" parent="/*">
+            <feature name="AirshipAdapter">
+                <param name="ios-package" value="AirshipAdapterPlugin"/>
+                <param name="onload" value="true" />
+            </feature>
+        </config-file>
+        <header-file src="src/ios/AirshipAdapterPlugin.h" />
+        <source-file src="src/ios/AirshipAdapterPlugin.m" />
+        
+        <podspec>
+            <config>
+                <source url="https://cdn.cocoapods.org"/>
+            </config>
+            <pods use-frameworks="true">
+              <pod name="GimbalAirshipAdapter" spec="2.1.1"/>
+            </pods>
+        </podspec>
+    </platform>
 </plugin>

--- a/plugin.xml
+++ b/plugin.xml
@@ -22,12 +22,12 @@
 		<config-file parent="/*" target="res/xml/config.xml">
 			<feature name="AirshipAdapter">
 				<param name="android-package" value="com.gimbal.airship.AirshipAdapterPlugin" />
+				<param name="onload" value="true"/>
 			</feature>
 		</config-file>
 
 		<config-file parent="/*" target="AndroidManifest.xml">
-			<uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
-			<uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
+			<uses-permission android:name="android.permission.ACCESS_BACKGROUND_LOCATION" />
 		</config-file>
 		
 		<source-file src="src/android/AirshipAdapterPlugin.java" target-dir="src/com/gimbal/airship/" />

--- a/src/android/AirshipAdapterPlugin.java
+++ b/src/android/AirshipAdapterPlugin.java
@@ -1,21 +1,16 @@
 package com.gimbal.airship;
 
-import android.Manifest;
-import android.content.pm.PackageManager;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
-import androidx.core.app.ActivityCompat;
-
-import org.apache.cordova.CordovaPlugin;
 import org.apache.cordova.CallbackContext;
-
+import org.apache.cordova.CordovaPlugin;
+import org.apache.cordova.CordovaPreferences;
 import org.apache.cordova.LOG;
 import org.apache.cordova.PluginResult;
 import org.json.JSONArray;
 import org.json.JSONException;
 
-/**
- * This class echoes a string called from JavaScript.
- */
 public class AirshipAdapterPlugin extends CordovaPlugin {
     private static final String TAG = "GIMBAL-AIRSHIP";
 
@@ -23,13 +18,26 @@ public class AirshipAdapterPlugin extends CordovaPlugin {
     private static final String ACTION_STOP = "stop";
 
     private AirshipAdapter adapter;
+    private Configuration config;
 
     @Override
     protected void pluginInitialize() {
         super.pluginInitialize();
 
+        config = new Configuration(preferences);
+
+        onUiThread(() -> {
+            getAdapter().setShouldTrackCustomEntryEvent(config.getTrackEntries());
+            getAdapter().setShouldTrackCustomExitEvent(config.getTrackExits());
+            getAdapter().setShouldTrackRegionEvent(config.getTrackRegionEvents());
+
+            if (config.getAutoStart() && config.getApiKey() != null && !getAdapter().isStarted()) {
+                start(config.getApiKey());
+            }
+        });
     }
 
+    @SuppressWarnings("RedundantThrows")
     @Override
     public boolean execute(String action, JSONArray args, CallbackContext callbackContext)
             throws JSONException {
@@ -58,32 +66,81 @@ public class AirshipAdapterPlugin extends CordovaPlugin {
     }
 
     private void start(JSONArray args, CallbackContext callbackContext) {
-        if ((args.length() != 1) && (args.optString(0, null) != null)) {
-            callbackContext.error("start: Expected single, non-null API Key string argument");
+        String apiKey;
+
+        if (args.length() != 1) {
+            callbackContext.error("Expected one nullable string Gimbal API Key argument");
+            return;
         }
-        String apiKey = args.optString(0);
-        if (ActivityCompat.checkSelfPermission(cordova.getContext(),
-                Manifest.permission.ACCESS_FINE_LOCATION) != PackageManager.PERMISSION_GRANTED) {
-            try {
-                boolean isStarted = getAdapter().start(apiKey);
-                callbackContext.sendPluginResult(
-                        new PluginResult(PluginResult.Status.OK, isStarted));
-            } catch (Exception e) {
-                LOG.e(TAG, "Failed to start Gimbal Airship adapter", e);
-                callbackContext.error(e.getMessage());
-            }
+        if (args.optString(0, null) != null) {
+            LOG.d(TAG, "start: Using API key from arguments");
+            apiKey = args.optString(0);
         } else {
-            callbackContext
-                    .error("Location permission is required to start Gimbal Airship adapter");
+            LOG.d(TAG, "start: Using API key from preferences");
+            apiKey = config.getApiKey();
+        }
+
+        if (apiKey == null || apiKey.isEmpty()) {
+            callbackContext.error("API Key must be non-null and non-empty");
+        }
+
+        try {
+            boolean isStarted = start(apiKey);
+            callbackContext.sendPluginResult(new PluginResult(PluginResult.Status.OK, isStarted));
+        } catch (Exception e) {
+            callbackContext.error(e.getMessage());
+        }
+    }
+
+    private boolean start(String apiKey) {
+        try {
+            return getAdapter().start(apiKey);
+        } catch (Exception e) {
+            LOG.e(TAG, "start: Failed to start Gimbal Airship adapter", e);
+            throw e;
         }
     }
 
     private void stop(JSONArray args, CallbackContext callbackContext) {
         if (args.length() != 0) {
-            callbackContext.error("stop: Expected no arguments");
+            LOG.w(TAG, "stop: Expected no arguments");
         }
         getAdapter().stop();
         callbackContext.success();
     }
 
+    private static class Configuration {
+        private static final String GIMBAL_API_KEY = "com.gimbal.api_key.android";
+        private static final String GIMBAL_AUTO_START = "com.gimbal.auto_start";
+        private static final String GIMBAL_TRACK_ENTRIES = "com.gimbal.track_custom_events.entry";
+        private static final String GIMBAL_TRACK_EXITS = "com.gimbal.track_custom_events.exit";
+        private static final String GIMBAL_TRACK_REGION_EVENTS = "com.gimbal.track_region_events";
+
+        private final CordovaPreferences preferences;
+
+        Configuration(@NonNull CordovaPreferences preferences) {
+            this.preferences = preferences;
+        }
+
+        @Nullable
+        String getApiKey() {
+            return preferences.getString(GIMBAL_API_KEY, null);
+        }
+
+        boolean getAutoStart() {
+            return preferences.getBoolean(GIMBAL_AUTO_START, false);
+        }
+
+        boolean getTrackEntries() {
+            return preferences.getBoolean(GIMBAL_TRACK_ENTRIES, true);
+        }
+
+        boolean getTrackExits() {
+            return preferences.getBoolean(GIMBAL_TRACK_EXITS, true);
+        }
+
+        boolean getTrackRegionEvents() {
+            return preferences.getBoolean(GIMBAL_TRACK_REGION_EVENTS, false);
+        }
+    }
 }

--- a/src/android/AirshipAdapterPlugin.java
+++ b/src/android/AirshipAdapterPlugin.java
@@ -66,38 +66,29 @@ public class AirshipAdapterPlugin extends CordovaPlugin {
     }
 
     private void start(JSONArray args, CallbackContext callbackContext) {
-        String apiKey;
-
         if (args.length() != 1) {
-            callbackContext.error("Expected one nullable string Gimbal API Key argument");
+            callbackContext.error("start: expected one nullable string Gimbal API Key argument");
             return;
         }
-        if (args.optString(0, null) != null) {
-            LOG.d(TAG, "start: Using API key from arguments");
-            apiKey = args.optString(0);
-        } else {
-            LOG.d(TAG, "start: Using API key from preferences");
-            apiKey = config.getApiKey();
-        }
 
+        String apiKey = args.optString(0, null);
         if (apiKey == null || apiKey.isEmpty()) {
-            callbackContext.error("API Key must be non-null and non-empty");
+            apiKey = config.getApiKey();
+            if (apiKey == null || apiKey.isEmpty()) {
+                callbackContext.error("start: expected non-null Gimbal API Key argument, or com.gimbal.api_key.android preference");
+                return;
+            }
+            LOG.d(TAG, "start: Using API key from preferences");
+        } else {
+            LOG.d(TAG, "start: Using API key from arguments");
         }
 
         try {
-            boolean isStarted = start(apiKey);
+            boolean isStarted = getAdapter().start(apiKey);
             callbackContext.sendPluginResult(new PluginResult(PluginResult.Status.OK, isStarted));
         } catch (Exception e) {
-            callbackContext.error(e.getMessage());
-        }
-    }
-
-    private boolean start(String apiKey) {
-        try {
-            return getAdapter().start(apiKey);
-        } catch (Exception e) {
             LOG.e(TAG, "start: Failed to start Gimbal Airship adapter", e);
-            throw e;
+            callbackContext.error(e.getMessage());
         }
     }
 

--- a/src/android/plugin.gradle
+++ b/src/android/plugin.gradle
@@ -6,8 +6,7 @@ allprojects {
 }
 
 dependencies {
-  implementation 'com.gimbal.android.v4:airship-adapter:1.0.0'
+  implementation 'com.gimbal.android:airship-adapter:2.0.0+'
   
-  // Google Play Services
   implementation "com.google.android.gms:play-services-location:21.0.1+"
 }

--- a/src/ios/AirshipAdapterPlugin.h
+++ b/src/ios/AirshipAdapterPlugin.h
@@ -1,0 +1,12 @@
+#import <Foundation/Foundation.h>
+#import <Cordova/CDVPlugin.h>
+
+@import GimbalAirshipAdapter;
+
+@interface AirshipAdapterPlugin : CDVPlugin
+
+- (void)start:(CDVInvokedUrlCommand *)command;
+
+- (void)stop:(CDVInvokedUrlCommand *)command;
+
+@end

--- a/src/ios/AirshipAdapterPlugin.m
+++ b/src/ios/AirshipAdapterPlugin.m
@@ -1,0 +1,86 @@
+#import "AirshipAdapterPlugin.h"
+#import <Cordova/CDVPlugin.h>
+#import <CoreLocation/CoreLocation.h>
+
+@implementation AirshipAdapterPlugin
+
+-(void)pluginInitialize {
+    [super pluginInitialize];
+    
+    NSString *preferenceApiKey = [self preferenceApiKey];
+    
+    AirshipAdapter.shared.shouldTrackCustomEntryEvents = [self shouldTrackCustomEntryEvents];
+    AirshipAdapter.shared.shouldTrackCustomExitEvents = [self shouldTrackCustomExitEvents];
+    AirshipAdapter.shared.shouldTrackRegionEvents = [self shouldTrackRegionEvents];
+    [AirshipAdapter.shared restore];
+    
+    if ([self shouldAutostart] && preferenceApiKey != nil && !AirshipAdapter.shared.isStarted) {
+        [self startWithApiKey:preferenceApiKey];
+    }
+}
+
+-(NSString*)preferenceApiKey {
+    return [self.commandDelegate.settings objectForKey:@"com.gimbal.api_key.ios"];
+}
+
+-(bool)shouldAutostart {
+    NSString* autostartConfigStringPreference = [[self.commandDelegate.settings
+                                                  objectForKey:@"com.gimbal.auto_start"] lowercaseString];
+    return autostartConfigStringPreference != nil && [autostartConfigStringPreference isEqualToString:@"true"];
+
+}
+
+-(bool)shouldTrackCustomEntryEvents {
+    NSString* shouldTrackEntryStringPreference = [[self.commandDelegate.settings
+                                                   objectForKey:@"com.gimbal.track_custom_events.entry"] lowercaseString];
+    return shouldTrackEntryStringPreference == nil || [shouldTrackEntryStringPreference isEqualToString:@"true"];
+}
+
+-(bool)shouldTrackCustomExitEvents {
+    NSString* shouldTrackExitStringPreference = [[self.commandDelegate.settings
+                                                   objectForKey:@"com.gimbal.track_custom_events.exit"] lowercaseString];
+    return shouldTrackExitStringPreference == nil || [shouldTrackExitStringPreference isEqualToString:@"true"];
+}
+
+-(bool)shouldTrackRegionEvents {
+    NSString* shouldTrackRegionStringPreference = [[self.commandDelegate.settings
+                                                   objectForKey:@"com.gimbal.track_region_events"] lowercaseString];
+    return shouldTrackRegionStringPreference != nil && [shouldTrackRegionStringPreference isEqualToString:@"true"];
+}
+
+-(void)start:(CDVInvokedUrlCommand *)command {
+    NSString *apiKey = [command argumentAtIndex:0];
+    CDVPluginResult *result;
+
+    if (apiKey == nil || apiKey.length == 0) {
+        apiKey = [self preferenceApiKey];
+        if (apiKey == nil || apiKey.length == 0) {
+            result = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR
+                                       messageAsString:@"start: expected non-null Gimbal API Key argument, or com.gimbal.api_key.ios preference"];
+            [self.commandDelegate sendPluginResult:result callbackId:command.callbackId];
+            return;
+        } else {
+            NSLog(@"start: Using API key from preferences");
+        }
+    } else {
+        NSLog(@"start: Using API key from arguments");
+    }
+
+    bool isStarted = [self startWithApiKey:apiKey];
+    result = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK
+                                 messageAsBool:isStarted];
+    [self.commandDelegate sendPluginResult:result callbackId:command.callbackId];
+}
+
+-(bool)startWithApiKey:(NSString *)apiKey {
+    [AirshipAdapter.shared start:apiKey];
+    return AirshipAdapter.shared.isStarted;
+}
+
+-(void)stop:(CDVInvokedUrlCommand *)command {
+    [AirshipAdapter.shared stop];
+    CDVPluginResult *result = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
+    [self.commandDelegate sendPluginResult:result callbackId:command.callbackId];
+}
+
+@end

--- a/src/ios/GimbalAirshipAdapter.podspec
+++ b/src/ios/GimbalAirshipAdapter.podspec
@@ -1,0 +1,7 @@
+
+Pod::Spec.new do |s|
+  s.ios.deployment_target   = "11.0"
+  s.swift_version           = "5.0"
+  s.requires_arc            = true
+  s.dependency                "GimbalAirshipAdapter", "~> 2.1.0"
+end

--- a/www/AirshipAdapter.js
+++ b/www/AirshipAdapter.js
@@ -1,9 +1,46 @@
 var exec = require('cordova/exec');
 
+/**
+ * A success callback without arguments
+ *
+ * @callback successCallback
+ */
+
+/**
+ * A success callback that consumes a single boolean argument
+ *
+ * @callback booleanCallback
+ * @param {boolean} value
+ */
+
+/**
+ * An error callback without arguments
+ * 
+ * @callback errorCallback
+ */
+
+/**
+ * Starts the Airship Adapter with the specified Gimbal API key, or a key from Cordova preferences.
+ * Gimbal place events will trigger tracking of Airship CustomEvents or RegionEvents, if enabled
+ * via preferences.
+ * <p>
+ * Note that each of your Gimbal Apps for iOS and Android will have unique API keys.
+ * 
+ * @param {?string} apiKey - the Gimbal API key, or {@code null} to use Cordova preferences
+ * @param {booleanCallback} success - called upon successful start of the Airship Adapter.
+ *     The single boolean argument is whether the adapter started successfully.
+ * @param {errorCallback} error - called if this invocation fails
+ */
 exports.start = function(apiKey, success, error) {
-    exec(success, error, 'AirshipAdapter', 'start', [apiKey]);
+  exec(success, error, 'AirshipAdapter', 'start', [apiKey]);
 };
 
+/**
+ * Stops the Airship Adapter
+ * 
+ * @param {successCallback} success - called upon successful stop of the Airship Adapter.
+ * @param {errorCallback} error - called if this invocation fails
+ */
 exports.stop = function(success, error) {
     exec(success, error, 'AirshipAdapter', 'stop', []);
 };


### PR DESCRIPTION
### Added

- Android and iOS bindings for native adapters, with basic `start` and `stop` API
- optional plugin configuration via `config.xml` preferences
